### PR TITLE
Added output for getting OIDC url from the EKS cluster, to use for ma…

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -59,3 +59,7 @@ output "instance_profile_name" {
   value       = join("", aws_iam_instance_profile.workers.*.name)
 }
 
+output "eks_cluster_oidc_url" {
+  description = "The OIDC url for the EKS Cluster"
+  value       = aws_eks_cluster.this.identity.0.oidc.0.issuer
+}


### PR DESCRIPTION
To be able to use External Secrets in EKS (as a secrets map), we need to setup an Service Account, and map that to an IAM role. We need an Open ID Connector for that, and therefor we need the OIDC URL from EKS.

WIth terraform we can now generate the entire policy we need to use for assume