### PR TITLE
authenticator api alpha version is deprecated. Updated to v1beta1

### DIFF
--- a/templates/kubeconfig.tpl
+++ b/templates/kubeconfig.tpl
@@ -19,7 +19,7 @@ users:
 - name: aws
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: client.authentication.k8s.io/v1beta1
       command: aws-iam-authenticator
       args:
         - "token"


### PR DESCRIPTION
client.authentication.k8s.io/v1alpha1 is deprecated. Updated kubecongif.tpl to use client.authentication.k8s.io/v1beta1