### PR TITLE
Move module away from template_file

### DIFF
--- a/aws_auth_configmap.tf
+++ b/aws_auth_configmap.tf
@@ -9,17 +9,6 @@ provider "kubernetes" {
   config_path = local_file.kubeconfig.filename
 }
 
-data "template_file" "map_roles" {
-  count    = var.map_roles_count
-  template = file("${path.module}/templates/config_map_aws_map_roles.yaml.tpl")
-
-  vars = {
-    role_arn = var.map_roles[count.index]["role_arn"]
-    username = var.map_roles[count.index]["username"]
-    group    = lookup(var.map_roles[count.index], "group", "system:authenticated")
-  }
-}
-
 resource "kubernetes_config_map" "auth_config" {
   metadata {
     name      = "aws-auth"

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -7,22 +7,6 @@
 
 data "aws_caller_identity" "current" {}
 
-data "template_file" "kubeconfig" {
-  template = file("${path.module}/templates/kubeconfig.tpl")
-
-  vars = {
-    server                     = join("", aws_eks_cluster.this[*].endpoint)
-    certificate_authority_data = aws_eks_cluster.this.certificate_authority[0].data
-    cluster_name               = var.name
-    aws_role = format(
-      "arn:aws:iam::%s:role/%s",
-      data.aws_caller_identity.current.account_id,
-      var.aws_role_name,
-    )
-    aws_profile = var.aws_profile_name
-  }
-}
-
 resource "local_file" "kubeconfig" {
   content  = local.kubeconfig
   filename = local.kubeconfig_filename

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -24,7 +24,7 @@ data "template_file" "kubeconfig" {
 }
 
 resource "local_file" "kubeconfig" {
-  content  = join("", data.template_file.kubeconfig[*].rendered)
+  content  = local.kubeconfig
   filename = local.kubeconfig_filename
 
   depends_on = [aws_eks_cluster.this]

--- a/locals.tf
+++ b/locals.tf
@@ -7,6 +7,21 @@
 
 locals {
   kubeconfig_filename = "work/kubeconfig.yaml"
-  map_roles           = join("", data.template_file.map_roles[*].rendered)
+  map_roles = templatefile("${path.module}/templates/config_map_aws_map_roles.yaml.tpl",
+  {
+    map_roles = var.map_roles
+  })
+  kubeconfig = templatefile("${path.module}/templates/kubeconfig.tpl",
+  {
+    server                     = join("", aws_eks_cluster.this[*].endpoint)
+    certificate_authority_data = aws_eks_cluster.this.certificate_authority[0].data
+    cluster_name               = var.name
+    aws_role = format(
+      "arn:aws:iam::%s:role/%s",
+      data.aws_caller_identity.current.account_id,
+      var.aws_role_name,
+    )
+    aws_profile = var.aws_profile_name
+  })
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -13,7 +13,7 @@ locals {
   })
   kubeconfig = templatefile("${path.module}/templates/kubeconfig.tpl",
   {
-    server                     = join("", aws_eks_cluster.this[*].endpoint)
+    server                     = aws_eks_cluster.this.endpoint
     certificate_authority_data = aws_eks_cluster.this.certificate_authority[0].data
     cluster_name               = var.name
     aws_role = format(

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,7 +36,7 @@ output "eks_cluster_version" {
 
 output "kubeconfig" {
   description = "`kubeconfig` configuration to connect to the cluster using `kubectl`."
-  value       = join("", data.template_file.kubeconfig[*].rendered)
+  value       = local.kubeconfig
 }
 
 output "kubeconfig_path" {

--- a/templates/config_map_aws_map_roles.yaml.tpl
+++ b/templates/config_map_aws_map_roles.yaml.tpl
@@ -1,4 +1,6 @@
-- rolearn: ${role_arn}
-  username: ${username}
+%{ for r in map_roles ~}
+- rolearn: ${r.role_arn}
+  username: ${r.username}
   groups:
-    - ${group}
+    - ${lookup(r, "group", "system:authenticated")}
+%{ endfor ~}


### PR DESCRIPTION
Move the module away from using 'template_file', in order to be rid of the deprecated [hashicorp/template](https://registry.terraform.io/providers/hashicorp/template/latest/docs) provider and allow the usage of the darwin_arm64 version of terraform.